### PR TITLE
S3 stream read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ debug/
 target/
 
 # Test outputs
+parquet/
 out/
 *.osm.pbf
 *.osm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,28 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,15 +1114,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2220,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "osm-pbf-parquet"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2229,18 +2198,13 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
- "crossbeam",
- "crossbeam-channel",
  "flate2",
- "futures",
- "futures-core",
  "object_store",
  "osmpbf",
  "parquet",
  "rayon",
  "sysinfo",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "url",
 ]
@@ -3277,7 +3241,6 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3318,18 +3281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,12 +3288,8 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
- "futures-util",
- "hashbrown",
  "pin-project-lite",
- "slab",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1136,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2198,13 +2229,15 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
- "either",
+ "crossbeam",
+ "crossbeam-channel",
  "flate2",
  "futures",
  "futures-core",
  "object_store",
  "osmpbf",
  "parquet",
+ "rayon",
  "sysinfo",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,7 +206,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "half",
  "lexical-core",
@@ -385,380 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "aws-config"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 0.2.12",
- "ring",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "aws-credential-types"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "zeroize",
-]
-
-[[package]]
-name = "aws-runtime"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
-dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "1.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf69a87be33b6f125a93d5046b5f7395c26d1f449bf8d3927f5577463b6de0"
-dependencies = [
- "ahash",
- "aws-credential-types",
- "aws-runtime",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-checksums",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "hmac",
- "http 0.2.12",
- "http-body 0.4.6",
- "lru",
- "once_cell",
- "percent-encoding",
- "regex-lite",
- "sha2",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11822090cf501c316c6f75711d77b96fba30658e3867a7762e5e2f5d32d31e81"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a2a06ff89176123945d1bbe865603c4d7101bea216a550bb4d2e4e9ba74d74"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20a91795850826a6f456f4a48eff1dfa59a0e69bdbf5b8c50518fd372106574"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "http 0.2.12",
- "once_cell",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "crypto-bigint 0.5.5",
- "form_urlencoded",
- "hex",
- "hmac",
- "http 0.2.12",
- "http 1.1.0",
- "once_cell",
- "p256",
- "percent-encoding",
- "ring",
- "sha2",
- "subtle",
- "time",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-async"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "aws-smithy-checksums"
-version = "0.60.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
-dependencies = [
- "aws-smithy-http",
- "aws-smithy-types",
- "bytes",
- "crc32c",
- "crc32fast",
- "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
- "pin-project-lite",
- "sha1",
- "sha2",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-eventstream"
-version = "0.60.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
-dependencies = [
- "aws-smithy-types",
- "bytes",
- "crc32fast",
-]
-
-[[package]]
-name = "aws-smithy-http"
-version = "0.60.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9cd0ae3d97daa0a2bf377a4d8e8e1362cae590c4a1aad0d40058ebca18eb91e"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http-body 0.4.6",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-json"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
-]
-
-[[package]]
-name = "aws-smithy-runtime"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abbf454960d0db2ad12684a1640120e7557294b0ff8e2f11236290a1b293225"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "fastrand",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "httparse",
- "hyper 0.14.30",
- "hyper-rustls 0.24.2",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "rustls 0.21.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-runtime-api"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
-dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
- "bytes",
- "http 0.2.12",
- "http 1.1.0",
- "pin-project-lite",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-smithy-types"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee7cadb433c781d3299b916fbf620fea813bf38f49db282fb6858141a05cc8"
-dependencies = [
- "base64-simd",
- "bytes",
- "bytes-utils",
- "futures-core",
- "http 0.2.12",
- "http 1.1.0",
- "http-body 0.4.6",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "num-integer",
- "pin-project-lite",
- "pin-utils",
- "ryu",
- "serde",
- "time",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "aws-smithy-xml"
-version = "0.60.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
-name = "aws-types"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
-dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "rustc_version",
- "tracing",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,38 +394,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -866,16 +458,6 @@ name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
-
-[[package]]
-name = "bytes-utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
-dependencies = [
- "bytes",
- "either",
-]
 
 [[package]]
 name = "cast"
@@ -995,12 +577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,24 +611,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
 
 [[package]]
 name = "crc32fast"
@@ -1131,28 +689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,25 +720,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,7 +727,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1220,42 +736,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der",
- "elliptic-curve",
- "rfc6979",
- "signature",
-]
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct",
- "crypto-bigint 0.4.9",
- "der",
- "digest",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "equivalent"
@@ -1278,16 +762,6 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "flatbuffers"
@@ -1442,36 +916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
-name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,7 +926,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1506,10 +950,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1530,38 +970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -1577,23 +991,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1604,8 +1007,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1616,40 +1019,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1660,9 +1033,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1673,35 +1046,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.30",
- "log",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.11",
- "rustls-native-certs 0.7.1",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1714,9 +1071,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1954,15 +1311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "lru"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,12 +1413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,12 +1479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper 1.4.1",
+ "hyper",
  "itertools 0.13.0",
  "md-5",
  "parking_lot",
@@ -2191,10 +1533,7 @@ dependencies = [
 name = "osm-pbf-parquet"
 version = "0.6.0"
 dependencies = [
- "anyhow",
  "arrow",
- "aws-config",
- "aws-sdk-s3",
  "bytes",
  "clap",
  "criterion",
@@ -2221,23 +1560,6 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "rayon",
-]
-
-[[package]]
-name = "outref"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
-
-[[package]]
-name = "p256"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2",
 ]
 
 [[package]]
@@ -2277,7 +1599,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
@@ -2343,16 +1665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,12 +1697,6 @@ checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2479,7 +1785,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.11",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
@@ -2495,7 +1801,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.11",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
@@ -2607,12 +1913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,16 +1924,16 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -2643,16 +1943,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.11",
- "rustls-native-certs 0.7.1",
- "rustls-pemfile 2.1.2",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2661,17 +1961,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
 ]
 
 [[package]]
@@ -2725,18 +2014,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
@@ -2744,21 +2021,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.5",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2768,19 +2033,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2789,7 +2045,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -2798,16 +2054,6 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2849,30 +2095,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -2953,47 +2175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,16 +2232,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "static_assertions"
@@ -3167,36 +2338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,7 +2383,6 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -3261,21 +2401,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.11",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3412,34 +2542,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3765,12 +2877,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,7 +212,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
@@ -379,6 +385,380 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-config"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e95816a168520d72c0e7680c405a5a8c1fb6a035b4bc4b9d7b0de8e1a941697"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 0.2.12",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42c2d4218de4dcd890a109461e2f799a1a2ba3bcd2cde9af88360f5df9266c6"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4abf69a87be33b6f125a93d5046b5f7395c26d1f449bf8d3927f5577463b6de0"
+dependencies = [
+ "ahash",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11822090cf501c316c6f75711d77b96fba30658e3867a7762e5e2f5d32d31e81"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a2a06ff89176123945d1bbe865603c4d7101bea216a550bb4d2e4e9ba74d74"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20a91795850826a6f456f4a48eff1dfa59a0e69bdbf5b8c50518fd372106574"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.1.0",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b1689d001c4d4dc3cb386adb07d37786783aee3ac4b324bcadac116bf3d23"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9cd0ae3d97daa0a2bf377a4d8e8e1362cae590c4a1aad0d40058ebca18eb91e"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abbf454960d0db2ad12684a1640120e7557294b0ff8e2f11236290a1b293225"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "httparse",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls 0.21.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.1.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cee7cadb433c781d3299b916fbf620fea813bf38f49db282fb6858141a05cc8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.1.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,10 +774,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -458,6 +866,16 @@ name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cast"
@@ -577,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +1035,24 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "crc32fast"
@@ -689,6 +1131,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +1184,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +1210,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -736,10 +1220,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -762,6 +1278,16 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "flatbuffers"
@@ -916,6 +1442,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +1482,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -950,6 +1506,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -970,12 +1530,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -991,12 +1577,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1007,8 +1604,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1019,10 +1616,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1033,9 +1660,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1046,19 +1673,35 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.1.0",
+ "hyper 1.4.1",
  "hyper-util",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.23.11",
+ "rustls-native-certs 0.7.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -1071,9 +1714,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1311,6 +1954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +2065,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,12 +2137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "hyper",
+ "hyper 1.4.1",
  "itertools 0.13.0",
  "md-5",
  "parking_lot",
@@ -1533,18 +2191,24 @@ dependencies = [
 name = "osm-pbf-parquet"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
+ "aws-config",
+ "aws-sdk-s3",
  "bytes",
  "clap",
  "criterion",
+ "either",
  "flate2",
  "futures",
+ "futures-core",
  "object_store",
  "osmpbf",
  "parquet",
- "rayon",
  "sysinfo",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "url",
 ]
 
@@ -1560,6 +2224,23 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "rayon",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
 ]
 
 [[package]]
@@ -1599,7 +2280,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -1665,6 +2346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +2388,12 @@ checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1785,7 +2482,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.11",
  "thiserror",
  "tokio",
  "tracing",
@@ -1801,7 +2498,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.11",
  "slab",
  "thiserror",
  "tinyvec",
@@ -1913,6 +2610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,16 +2627,16 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -1943,16 +2646,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
+ "rustls 0.23.11",
+ "rustls-native-certs 0.7.1",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -1961,6 +2664,17 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -2014,6 +2728,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
@@ -2021,9 +2747,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2033,10 +2771,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2045,7 +2792,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -2054,6 +2801,16 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2095,6 +2852,30 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2175,6 +2956,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +3054,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2338,6 +3170,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,7 +3244,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -2401,13 +3265,35 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls",
+ "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2418,8 +3304,12 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -2542,16 +3432,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -2877,6 +3785,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,30 +1,24 @@
 [package]
 name = "osm-pbf-parquet"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.86"
 arrow = "52.1.0"
+aws-config = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
 bytes = "1.6.1"
 clap = { version = "4.5.9", features = ["derive"] }
 flate2 = { version = "1.0.30", features = ["zlib-ng"], default-features = false }
-futures = "0.3.30"
 object_store = {version = "0.10.2", features = ["aws"] }
 osmpbf = "0.3.4"
 parquet = { version = "52.1.0", features = ["async"] }
 rayon = "1.10.0"
 sysinfo = "0.30.13"
-# TODO - reduce feature set here?
-tokio = { version =  "1.38.1", features = ["full"] }
-tokio-util = {version = "0.7.11", features = ["full"] }
-tokio-stream = {version = "0.1.15", features = ["full"] }
+tokio = { version =  "1.38.1", features = ["rt", "rt-multi-thread", "io-util"] }
+tokio-util = {version = "0.7.11", features = ["io-util"] }
 url = "2.5.2"
-aws-config = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
-futures-core = "0.3.30"
-anyhow = "1.0.86"
-crossbeam = "0.8.4"
-crossbeam-channel = "0.5.13"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.30"
 object_store = {version = "0.10.2", features = ["aws"] }
 osmpbf = "0.3.4"
 parquet = { version = "52.1.0", features = ["async"] }
-# rayon = "1.10.0"
+rayon = "1.10.0"
 sysinfo = "0.30.13"
 # TODO - reduce feature set here?
 tokio = { version =  "1.38.1", features = ["full"] }
@@ -23,7 +23,8 @@ aws-config = { version = "1", features = ["behavior-version-latest", "rt-tokio"]
 aws-sdk-s3 = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
 futures-core = "0.3.30"
 anyhow = "1.0.86"
-either = "1.13.0"
+crossbeam = "0.8.4"
+crossbeam-channel = "0.5.13"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,18 @@ futures = "0.3.30"
 object_store = {version = "0.10.2", features = ["aws"] }
 osmpbf = "0.3.4"
 parquet = { version = "52.1.0", features = ["async"] }
-rayon = "1.10.0"
+# rayon = "1.10.0"
 sysinfo = "0.30.13"
-tokio = { version =  "1.38.1", features = ["rt", "rt-multi-thread"] }
+# TODO - reduce feature set here?
+tokio = { version =  "1.38.1", features = ["full"] }
+tokio-util = {version = "0.7.11", features = ["full"] }
+tokio-stream = {version = "0.1.15", features = ["full"] }
 url = "2.5.2"
+aws-config = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
+futures-core = "0.3.30"
+anyhow = "1.0.86"
+either = "1.13.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,12 @@ version = "0.6.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.86"
 arrow = "52.1.0"
-aws-config = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest", "rt-tokio"] }
 bytes = "1.6.1"
 clap = { version = "4.5.9", features = ["derive"] }
 flate2 = { version = "1.0.30", features = ["zlib-ng"], default-features = false }
 object_store = {version = "0.10.2", features = ["aws"] }
-osmpbf = "0.3.4"
+osmpbf = { version = "0.3.4", features = ["zlib-ng"], default-features = false }
 parquet = { version = "52.1.0", features = ["async"] }
 rayon = "1.10.0"
 sysinfo = "0.30.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@ fn s3_read(
         .unwrap();
     let s3_async_reader = rt.block_on(create_s3_async_reader(url));
     let s3_sync_reader = SyncIoBridge::new_with_handle(s3_async_reader, rt.handle().clone());
-    let sync_buf_reader = std::io::BufReader::with_capacity(DEFAULT_BUF_READER_SIZE, s3_sync_reader);
+    let sync_buf_reader =
+        std::io::BufReader::with_capacity(DEFAULT_BUF_READER_SIZE, s3_sync_reader);
     let blob_reader = BlobReader::new(sync_buf_reader);
 
     // Using rayon parallelize bridge here because SyncIoBridge can't run on tokio-enabled threads
@@ -116,7 +117,7 @@ fn local_read(
 ) -> Result<(), osmpbf::Error> {
     let file = File::open(path).unwrap();
     let reader = std::io::BufReader::with_capacity(DEFAULT_BUF_READER_SIZE, file);
-    let blob_reader = BlobReader::new(reader).unwrap();
+    let blob_reader = BlobReader::new(reader);
     blob_reader.par_bridge().for_each(|blob| {
         if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
             process_block(block, sinkpools.clone(), filenums.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ fn local_read(
 ) -> Result<(), osmpbf::Error> {
     let file = File::open(path).unwrap();
     let reader = std::io::BufReader::with_capacity(DEFAULT_BUF_READER_SIZE, file);
-    let blob_reader = BlobReader::new_seekable(reader).unwrap();
+    let blob_reader = BlobReader::new(reader).unwrap();
     blob_reader.par_bridge().for_each(|blob| {
         if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
             process_block(block, sinkpools.clone(), filenums.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,88 +1,266 @@
+// use core::sync;
 use std::collections::HashMap;
-use std::io;
+use std::thread;
+use std::error;
+use std::io::{self};
 use std::sync::{Arc, Mutex};
+use anyhow::Error;
+// use bytes::Bytes;
+use futures::StreamExt;
+// use futures_core::stream::Stream;
+// use futures_util::stream::StreamExt;
 
-use osmpbf::{BlobDecode, BlobReader, Element};
-use rayon::iter::ParallelBridge;
-use rayon::iter::ParallelIterator;
+use osmpbf::{Blob, BlobDecode, BlobReader, Element};
+// use rayon::iter::ParallelBridge;
+// use rayon::iter::ParallelIterator;
+use tokio::io::AsyncBufRead;
+use tokio_util::io::{StreamReader, SyncIoBridge};
+use tokio_stream::{self as stream};
+// use tokio_util::io::StreamReader;
 
 pub mod osm_arrow;
 pub mod sink;
 pub mod util;
 use crate::osm_arrow::OSMType;
 use crate::sink::ElementSink;
-use crate::util::{Args, ARGS};
+use crate::util::{Args, ARGS, cpu_count};
 
-pub fn driver(args: Args) -> Result<(), io::Error> {
+pub async fn create_s3_sync_reader() -> Result<SyncIoBridge<impl AsyncBufRead>, anyhow::Error> {
+    // let args = ARGS.get().unwrap();
+// pub async fn create_sync_reader<T>(args: Args) -> Result<BufReader<T>, std::io::Error> {
+    // Bucket: omf-transp-public-devo-us-west-2
+    // Small: test/pbf/greenland-latest.osm.pbf
+    // Large: test/pbf/mexico-latest.osm.pbf
+    let sdk_config = aws_config::load_from_env().await;
+    let client = aws_sdk_s3::Client::new(&sdk_config);
+    let stream = client
+        .get_object()
+        // TODO - parse these out from args input
+        .bucket("omf-transp-public-devo-us-west-2")
+        .key("test/pbf/greenland-latest.osm.pbf")
+        .send()
+        .await?;
+
+    // Convert the stream into a sync reader
+    let async_read = stream.body.into_async_read();
+    // Need to jump off the main tokio runtime 
+    let sync_reader = SyncIoBridge::new(async_read);
+    Ok(sync_reader)
+}
+
+// pub fn async_driver(args: Args) -> Result<(), io::Error> {
+//     // TODO - validation of args
+//     // Store value for reading across threads (write-once)
+//     let _ = ARGS.set(args.clone());
+
+
+
+//     let sinkpools = HashMap::from([
+//         (OSMType::Node, Arc::new(Mutex::new(vec![]))),
+//         (OSMType::Way, Arc::new(Mutex::new(vec![]))),
+//         (OSMType::Relation, Arc::new(Mutex::new(vec![]))),
+//     ]);
+
+//     let filenums = HashMap::from([
+//         (OSMType::Node, Arc::new(Mutex::new(0))),
+//         (OSMType::Way, Arc::new(Mutex::new(0))),
+//         (OSMType::Relation, Arc::new(Mutex::new(0))),
+//     ]);
+
+//     let get_sink_from_pool = |osm_type: OSMType| -> Result<ElementSink, std::io::Error> {
+//         {
+//             let mut pool = sinkpools[&osm_type].lock().unwrap();
+//             if let Some(sink) = pool.pop() {
+//                 return Ok(sink);
+//             }
+//         }
+//         ElementSink::new(filenums[&osm_type].clone(), osm_type)
+//     };
+
+//     let add_sink_to_pool = |sink: ElementSink| {
+//         let osm_type = sink.osm_type.clone();
+//         let mut pool = sinkpools[&osm_type].lock().unwrap();
+//         pool.push(sink);
+//     };
+
+//     // TODO - async blob reader that can use par_bridge
+//     reader
+//         .par_bridge()
+//         .try_for_each(|blob| -> Result<(), io::Error> {
+//             if let BlobDecode::OsmData(block) = blob?.decode()? {
+//                 let mut node_sink = get_sink_from_pool(OSMType::Node)?;
+//                 let mut way_sink = get_sink_from_pool(OSMType::Way)?;
+//                 let mut rel_sink = get_sink_from_pool(OSMType::Relation)?;
+//                 for elem in block.elements() {
+//                     match elem {
+//                         Element::Node(ref node) => {
+//                             node_sink.add_node(node)?;
+//                         }
+//                         Element::DenseNode(ref node) => {
+//                             node_sink.add_dense_node(node)?;
+//                         }
+//                         Element::Way(ref way) => {
+//                             way_sink.add_way(way)?;
+//                         }
+//                         Element::Relation(ref rel) => {
+//                             rel_sink.add_relation(rel)?;
+//                         }
+//                     }
+//                 }
+//                 add_sink_to_pool(node_sink);
+//                 add_sink_to_pool(way_sink);
+//                 add_sink_to_pool(rel_sink);
+//             }
+//             Ok(())
+//         })?;
+
+//     {
+//         for sinkpool in sinkpools.values() {
+//             let mut pool = sinkpool.lock().unwrap();
+//             for mut sink in pool.drain(..) {
+//                 sink.finish();
+//             }
+//         }
+//     }
+//     Ok(())
+// }
+
+fn get_sink_from_pool(osm_type: OSMType, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<ElementSink, std::io::Error> {
+    {
+        let mut pool = sinkpools[&osm_type].lock().unwrap();
+        if let Some(sink) = pool.pop() {
+            return Ok(sink);
+        }
+    }
+    ElementSink::new(filenums[&osm_type].clone(), osm_type)
+}
+
+fn add_sink_to_pool(sink: ElementSink, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>) {
+    let osm_type = sink.osm_type.clone();
+    let mut pool = sinkpools[&osm_type].lock().unwrap();
+    pool.push(sink);
+}
+
+async fn process_blob(blob: Blob, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) {
+    // TODO - no unwraps
+    if let BlobDecode::OsmData(block) = blob.decode().unwrap() {
+        let mut node_sink = get_sink_from_pool(OSMType::Node, sinkpools.clone(), filenums.clone()).unwrap();
+        let mut way_sink = get_sink_from_pool(OSMType::Way, sinkpools.clone(), filenums.clone()).unwrap();
+        let mut rel_sink = get_sink_from_pool(OSMType::Relation, sinkpools.clone(), filenums.clone()).unwrap();
+        for elem in block.elements() {
+            match elem {
+                Element::Node(ref node) => {
+                    node_sink.add_node(node).await;
+                }
+                Element::DenseNode(ref node) => {
+                    node_sink.add_dense_node(node).await;
+                }
+                Element::Way(ref way) => {
+                    way_sink.add_way(way).await;
+                }
+                Element::Relation(ref rel) => {
+                    rel_sink.add_relation(rel).await;
+                }
+            }
+        }
+        add_sink_to_pool(node_sink, sinkpools.clone());
+        add_sink_to_pool(way_sink, sinkpools.clone());
+        add_sink_to_pool(rel_sink, sinkpools.clone());
+    }
+}
+
+async fn s3_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
+    // let rt = tokio::runtime::Builder::new_multi_thread()
+    // .enable_all()
+    // .build()
+    // .unwrap();
+    // TODO - unwraps
+    // tokio::task::spawn_blocking(move || {
+    let sync_reader = tokio::task::block_in_place(|| create_s3_sync_reader()).await.unwrap();
+    let blob_reader = BlobReader::new(sync_reader);
+    let stream = stream::iter(blob_reader);
+    stream.for_each_concurrent(cpu_count() / 2, |blob| async {
+        process_blob(blob.unwrap(), sinkpools.clone(), filenums.clone()).await
+    }).await;
+    // rt.block_on(future.await);
+    Ok(())
+}
+
+async fn local_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
+    // let rt = tokio::runtime::Builder::new_multi_thread()
+    // .enable_all()
+    // .build()
+    // .unwrap();
+    let blob_reader = BlobReader::from_path(ARGS.get().unwrap().input.clone()).unwrap();
+    let stream = stream::iter(blob_reader);
+    stream.for_each_concurrent(cpu_count() / 2, |blob| async {
+        // TODO - fix unwrap
+        process_blob(blob.unwrap(), sinkpools.clone(), filenums.clone()).await
+    }).await;
+    // rt.block_on(future.await);
+    Ok(())
+}
+
+pub async fn driver(args: Args) -> Result<(), io::Error> {
     // TODO - validation of args
     // Store value for reading across threads (write-once)
     let _ = ARGS.set(args.clone());
 
-    let reader = BlobReader::from_path(args.input)?;
+    // if args.input.starts_with("s3://") {
+    // } else {
+    //     let reader = BlobReader::from_path(args.input).unwrap();
+    // }
+    // TODO - need async blob reader
 
-    let sinkpools = HashMap::from([
+    let sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>> = Arc::new(HashMap::from([
         (OSMType::Node, Arc::new(Mutex::new(vec![]))),
         (OSMType::Way, Arc::new(Mutex::new(vec![]))),
         (OSMType::Relation, Arc::new(Mutex::new(vec![]))),
-    ]);
+    ]));
 
-    let filenums = HashMap::from([
+    let filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>> = Arc::new(HashMap::from([
         (OSMType::Node, Arc::new(Mutex::new(0))),
         (OSMType::Way, Arc::new(Mutex::new(0))),
         (OSMType::Relation, Arc::new(Mutex::new(0))),
-    ]);
+    ]));
 
-    let get_sink_from_pool = |osm_type: OSMType| -> Result<ElementSink, std::io::Error> {
-        {
-            let mut pool = sinkpools[&osm_type].lock().unwrap();
-            if let Some(sink) = pool.pop() {
-                return Ok(sink);
-            }
-        }
-        ElementSink::new(filenums[&osm_type].clone(), osm_type)
-    };
+    // TODO - fix this with match or something
+    if args.input.starts_with("s3://") {
+        s3_read(sinkpools.clone(), filenums.clone()).await;
+    } else {
+        local_read(sinkpools.clone(), filenums.clone()).await;
+    }
 
-    let add_sink_to_pool = |sink: ElementSink| {
-        let osm_type = sink.osm_type.clone();
-        let mut pool = sinkpools[&osm_type].lock().unwrap();
-        pool.push(sink);
-    };
+    // let get_sink_from_pool = |osm_type: OSMType| -> Result<ElementSink, std::io::Error> {
 
-    reader
-        .par_bridge()
-        .try_for_each(|blob| -> Result<(), io::Error> {
-            if let BlobDecode::OsmData(block) = blob?.decode()? {
-                let mut node_sink = get_sink_from_pool(OSMType::Node)?;
-                let mut way_sink = get_sink_from_pool(OSMType::Way)?;
-                let mut rel_sink = get_sink_from_pool(OSMType::Relation)?;
-                for elem in block.elements() {
-                    match elem {
-                        Element::Node(ref node) => {
-                            node_sink.add_node(node)?;
-                        }
-                        Element::DenseNode(ref node) => {
-                            node_sink.add_dense_node(node)?;
-                        }
-                        Element::Way(ref way) => {
-                            way_sink.add_way(way)?;
-                        }
-                        Element::Relation(ref rel) => {
-                            rel_sink.add_relation(rel)?;
-                        }
-                    }
-                }
-                add_sink_to_pool(node_sink);
-                add_sink_to_pool(way_sink);
-                add_sink_to_pool(rel_sink);
-            }
-            Ok(())
-        })?;
+    // };
+
+    // let add_sink_to_pool = 
+
+    // let stream = stream::iter(reader);
+
+
+
+    // reader
+    //     .par_bridge()
+    //     .try_for_each(|blob| -> Result<(), io::Error> {
+
+    // stream::StreamExt::try_for_each(stream, |blob| -> Result<(), io::Error> {
+    //     StreamExt::chunks_timeout(self, max_size, duration);
+        // rt.enter();
+        // TODO - async move?
+    // stream.try_for_each_concurrent(cpu_count() / 2, |blob| -> Result<(), io::Error> {
+    //     if let BlobDecode::OsmData(block) = blob?.decode()? {
+    //         process_block(block, sinkpools, filenums)?;
+    //     }
+    //     Ok(())
+    // })?;
 
     {
         for sinkpool in sinkpools.values() {
             let mut pool = sinkpool.lock().unwrap();
             for mut sink in pool.drain(..) {
-                sink.finish();
+                sink.finish().await;
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,41 @@
 use std::collections::HashMap;
-use std::time::Duration;
-use std::{boxed, thread};
 use std::io::{self};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::{boxed, thread};
 
 use futures::{future, StreamExt};
 use osmpbf::{BlobDecode, BlobReader, Element, PrimitiveBlock};
 use rayon::iter::ParallelBridge;
 use rayon::iter::ParallelIterator;
 use tokio::io::AsyncBufRead;
-use tokio_util::io::SyncIoBridge;
 use tokio_stream::{self as stream};
+use tokio_util::io::SyncIoBridge;
 
 pub mod osm_arrow;
 pub mod sink;
 pub mod util;
 use crate::osm_arrow::OSMType;
 use crate::sink::ElementSink;
-use crate::util::{Args, ARGS, cpu_count};
+use crate::util::{cpu_count, Args, ARGS};
 
 pub async fn create_s3_async_reader() -> Result<impl AsyncBufRead, anyhow::Error> {
     let input_url = ARGS.get().unwrap().input.clone();
-    let path = input_url.strip_prefix("s3://").expect("Error parsing S3 path");
+    let path = input_url
+        .strip_prefix("s3://")
+        .expect("Error parsing S3 path");
     let (bucket, key) = path.split_once('/').expect("Error parsing S3 path");
     let sdk_config = aws_config::load_from_env().await;
     let client = aws_sdk_s3::Client::new(&sdk_config);
-    let stream = client
-        .get_object()
-        .bucket(bucket)
-        .key(key)
-        .send()
-        .await?;
+    let stream = client.get_object().bucket(bucket).key(key).send().await?;
     Ok(stream.body.into_async_read())
 }
 
-fn get_sink_from_pool(osm_type: OSMType, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<ElementSink, std::io::Error> {
+fn get_sink_from_pool(
+    osm_type: OSMType,
+    sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>,
+    filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>,
+) -> Result<ElementSink, std::io::Error> {
     {
         let mut pool = sinkpools[&osm_type].lock().unwrap();
         if let Some(sink) = pool.pop() {
@@ -44,18 +45,28 @@ fn get_sink_from_pool(osm_type: OSMType, sinkpools: Arc<HashMap<OSMType, Arc<Mut
     ElementSink::new(filenums[&osm_type].clone(), osm_type)
 }
 
-fn add_sink_to_pool(sink: ElementSink, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>) {
+fn add_sink_to_pool(
+    sink: ElementSink,
+    sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>,
+) {
     let osm_type = sink.osm_type.clone();
     let mut pool = sinkpools[&osm_type].lock().unwrap();
     pool.push(sink);
 }
 
-fn process_block(block: PrimitiveBlock, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) {
+fn process_block(
+    block: PrimitiveBlock,
+    sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>,
+    filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>,
+) {
     // let sinkpools = sinkpools.clone();
     // let filenums = filenums.clone();
-    let mut node_sink = get_sink_from_pool(OSMType::Node, sinkpools.clone(), filenums.clone()).unwrap();
-    let mut way_sink = get_sink_from_pool(OSMType::Way, sinkpools.clone(), filenums.clone()).unwrap();
-    let mut rel_sink = get_sink_from_pool(OSMType::Relation, sinkpools.clone(), filenums.clone()).unwrap();
+    let mut node_sink =
+        get_sink_from_pool(OSMType::Node, sinkpools.clone(), filenums.clone()).unwrap();
+    let mut way_sink =
+        get_sink_from_pool(OSMType::Way, sinkpools.clone(), filenums.clone()).unwrap();
+    let mut rel_sink =
+        get_sink_from_pool(OSMType::Relation, sinkpools.clone(), filenums.clone()).unwrap();
     for element in block.elements() {
         match element {
             Element::Node(ref node) => {
@@ -77,10 +88,16 @@ fn process_block(block: PrimitiveBlock, sinkpools: Arc<HashMap<OSMType, Arc<Mute
     add_sink_to_pool(rel_sink, sinkpools.clone());
 }
 
-fn s3_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
+fn s3_read(
+    sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>,
+    filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>,
+) -> Result<(), osmpbf::Error> {
     // Create sync reader because underlying BlobReader is not async
     // Backed by multi-threaded runtime to allow fetch concurrency
-    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let async_reader = rt.block_on(create_s3_async_reader()).unwrap();
     let sync_reader = SyncIoBridge::new_with_handle(async_reader, rt.handle().clone());
     let blob_reader = BlobReader::new(std::io::BufReader::new(sync_reader));
@@ -94,15 +111,16 @@ fn s3_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filen
     Ok(())
 }
 
-fn local_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
+fn local_read(
+    sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>,
+    filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>,
+) -> Result<(), osmpbf::Error> {
     let blob_reader = BlobReader::from_path(ARGS.get().unwrap().input.clone()).unwrap();
-    blob_reader
-        .par_bridge()
-        .for_each(|blob| {
-            if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
-                process_block(block, sinkpools.clone(), filenums.clone());
-            }
-        });
+    blob_reader.par_bridge().for_each(|blob| {
+        if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
+            process_block(block, sinkpools.clone(), filenums.clone());
+        }
+    });
     Ok(())
 }
 
@@ -130,7 +148,10 @@ pub fn driver(args: Args) -> Result<(), io::Error> {
     }
 
     {
-        let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         for sinkpool in sinkpools.values() {
             let mut pool = sinkpool.lock().unwrap();
             for mut sink in pool.drain(..) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@ fn s3_read(
         .unwrap();
     let s3_async_reader = rt.block_on(create_s3_async_reader(url));
     let s3_sync_reader = SyncIoBridge::new_with_handle(s3_async_reader, rt.handle().clone());
-    let blob_reader = BlobReader::new(s3_sync_reader);
+    let sync_buf_reader = std::io::BufReader::with_capacity(DEFAULT_BUF_READER_SIZE, s3_sync_reader);
+    let blob_reader = BlobReader::new(sync_buf_reader);
 
     // Using rayon parallelize bridge here because SyncIoBridge can't run on tokio-enabled threads
     blob_reader.par_bridge().for_each(|blob| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,16 @@
-// use core::sync;
 use std::collections::HashMap;
-use std::thread;
-use std::error;
+use std::time::Duration;
+use std::{boxed, thread};
 use std::io::{self};
 use std::sync::{Arc, Mutex};
-use anyhow::Error;
-// use bytes::Bytes;
-use futures::StreamExt;
-// use futures_core::stream::Stream;
-// use futures_util::stream::StreamExt;
 
-use osmpbf::PrimitiveBlock;
-use osmpbf::{Blob, BlobDecode, BlobReader, Element};
-// use rayon::iter::ParallelBridge;
-// use rayon::iter::ParallelIterator;
+use futures::{future, StreamExt};
+use osmpbf::{BlobDecode, BlobReader, Element, PrimitiveBlock};
+use rayon::iter::ParallelBridge;
+use rayon::iter::ParallelIterator;
 use tokio::io::AsyncBufRead;
-use tokio_util::io::{StreamReader, SyncIoBridge};
+use tokio_util::io::SyncIoBridge;
 use tokio_stream::{self as stream};
-// use tokio_util::io::StreamReader;
 
 pub mod osm_arrow;
 pub mod sink;
@@ -27,101 +20,19 @@ use crate::sink::ElementSink;
 use crate::util::{Args, ARGS, cpu_count};
 
 pub async fn create_s3_async_reader() -> Result<impl AsyncBufRead, anyhow::Error> {
-    // let args = ARGS.get().unwrap();
-// pub async fn create_sync_reader<T>(args: Args) -> Result<BufReader<T>, std::io::Error> {
-    // Bucket: omf-transp-public-devo-us-west-2
-    // Small: test/pbf/greenland-latest.osm.pbf
-    // Large: test/pbf/mexico-latest.osm.pbf
+    let input_url = ARGS.get().unwrap().input.clone();
+    let path = input_url.strip_prefix("s3://").expect("Error parsing S3 path");
+    let (bucket, key) = path.split_once('/').expect("Error parsing S3 path");
     let sdk_config = aws_config::load_from_env().await;
     let client = aws_sdk_s3::Client::new(&sdk_config);
     let stream = client
         .get_object()
-        // TODO - parse these out from args input
-        .bucket("omf-transp-public-devo-us-west-2")
-        .key("test/pbf/greenland-latest.osm.pbf")
+        .bucket(bucket)
+        .key(key)
         .send()
         .await?;
-
-    // Convert the stream into a sync reader
     Ok(stream.body.into_async_read())
 }
-
-// pub fn async_driver(args: Args) -> Result<(), io::Error> {
-//     // TODO - validation of args
-//     // Store value for reading across threads (write-once)
-//     let _ = ARGS.set(args.clone());
-
-
-
-//     let sinkpools = HashMap::from([
-//         (OSMType::Node, Arc::new(Mutex::new(vec![]))),
-//         (OSMType::Way, Arc::new(Mutex::new(vec![]))),
-//         (OSMType::Relation, Arc::new(Mutex::new(vec![]))),
-//     ]);
-
-//     let filenums = HashMap::from([
-//         (OSMType::Node, Arc::new(Mutex::new(0))),
-//         (OSMType::Way, Arc::new(Mutex::new(0))),
-//         (OSMType::Relation, Arc::new(Mutex::new(0))),
-//     ]);
-
-//     let get_sink_from_pool = |osm_type: OSMType| -> Result<ElementSink, std::io::Error> {
-//         {
-//             let mut pool = sinkpools[&osm_type].lock().unwrap();
-//             if let Some(sink) = pool.pop() {
-//                 return Ok(sink);
-//             }
-//         }
-//         ElementSink::new(filenums[&osm_type].clone(), osm_type)
-//     };
-
-//     let add_sink_to_pool = |sink: ElementSink| {
-//         let osm_type = sink.osm_type.clone();
-//         let mut pool = sinkpools[&osm_type].lock().unwrap();
-//         pool.push(sink);
-//     };
-
-//     // TODO - async blob reader that can use par_bridge
-//     reader
-//         .par_bridge()
-//         .try_for_each(|blob| -> Result<(), io::Error> {
-//             if let BlobDecode::OsmData(block) = blob?.decode()? {
-//                 let mut node_sink = get_sink_from_pool(OSMType::Node)?;
-//                 let mut way_sink = get_sink_from_pool(OSMType::Way)?;
-//                 let mut rel_sink = get_sink_from_pool(OSMType::Relation)?;
-//                 for elem in block.elements() {
-//                     match elem {
-//                         Element::Node(ref node) => {
-//                             node_sink.add_node(node)?;
-//                         }
-//                         Element::DenseNode(ref node) => {
-//                             node_sink.add_dense_node(node)?;
-//                         }
-//                         Element::Way(ref way) => {
-//                             way_sink.add_way(way)?;
-//                         }
-//                         Element::Relation(ref rel) => {
-//                             rel_sink.add_relation(rel)?;
-//                         }
-//                     }
-//                 }
-//                 add_sink_to_pool(node_sink);
-//                 add_sink_to_pool(way_sink);
-//                 add_sink_to_pool(rel_sink);
-//             }
-//             Ok(())
-//         })?;
-
-//     {
-//         for sinkpool in sinkpools.values() {
-//             let mut pool = sinkpool.lock().unwrap();
-//             for mut sink in pool.drain(..) {
-//                 sink.finish();
-//             }
-//         }
-//     }
-//     Ok(())
-// }
 
 fn get_sink_from_pool(osm_type: OSMType, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<ElementSink, std::io::Error> {
     {
@@ -140,12 +51,13 @@ fn add_sink_to_pool(sink: ElementSink, sinkpools: Arc<HashMap<OSMType, Arc<Mutex
 }
 
 fn process_block(block: PrimitiveBlock, sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) {
-    // TODO - no unwraps
+    // let sinkpools = sinkpools.clone();
+    // let filenums = filenums.clone();
     let mut node_sink = get_sink_from_pool(OSMType::Node, sinkpools.clone(), filenums.clone()).unwrap();
     let mut way_sink = get_sink_from_pool(OSMType::Way, sinkpools.clone(), filenums.clone()).unwrap();
     let mut rel_sink = get_sink_from_pool(OSMType::Relation, sinkpools.clone(), filenums.clone()).unwrap();
-    for elem in block.elements() {
-        match elem {
+    for element in block.elements() {
+        match element {
             Element::Node(ref node) => {
                 node_sink.add_node(node);
             }
@@ -160,120 +72,44 @@ fn process_block(block: PrimitiveBlock, sinkpools: Arc<HashMap<OSMType, Arc<Mute
             }
         }
     }
-
-    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
-    // TODO - probably move this back into the element adds while it is piped
-    rt.block_on(node_sink.increment_and_cycle());
-    rt.block_on(way_sink.increment_and_cycle());
-    rt.block_on(rel_sink.increment_and_cycle());
-    
     add_sink_to_pool(node_sink, sinkpools.clone());
     add_sink_to_pool(way_sink, sinkpools.clone());
     add_sink_to_pool(rel_sink, sinkpools.clone());
 }
 
 fn s3_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
-    // let rt = tokio::runtime::Builder::new_multi_thread()
-    // .enable_all()
-    // .build()
-    // .unwrap();
-    // TODO - unwraps
-    // tokio::task::spawn_blocking(move || {
+    // Create sync reader because underlying BlobReader is not async
+    // Backed by multi-threaded runtime to allow fetch concurrency
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
     let async_reader = rt.block_on(create_s3_async_reader()).unwrap();
-    // Need tokio runtime, but don't need to run on it otherwise
     let sync_reader = SyncIoBridge::new_with_handle(async_reader, rt.handle().clone());
-    // rt.
-    let blob_reader = BlobReader::new(std::io::BufReader::new(sync_reader)); // TODO - std::io::BufReader here?
-    // let stream = stream::iter(blob_reader);
-    // stream.for
-    // TODO - maybe block on each blob read?
+    let blob_reader = BlobReader::new(std::io::BufReader::new(sync_reader));
 
-
-
-    // TODO - cleanup
-    // TODO - stream element reads
-    // TODO - pipe out to other threads
-
-
-    let futures = blob_reader.filter_map(|blob| {
-        match blob.unwrap().decode() {
-            Ok(BlobDecode::OsmData(block)) => {
-                let sinkpools = sinkpools.clone();
-                let filenums = filenums.clone();
-                Some(
-                    process_block(block, sinkpools, filenums)
-                //     rt.spawn(async move {
-                //     // process_block(block, sinkpools, filenums).await
-                // })
-                )
-                // Some(1)
-            },
-            _ => {
-                // Ignore other blocks
-                None
-            }
+    for blob in blob_reader {
+        if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
+            process_block(block, sinkpools.clone(), filenums.clone());
         }
-        // let decoded = blob.unwrap().decode().unwrap();
-        // match blob.ok()?.decode() {
-        //     Ok(BlobDecode::OsmData(block)) => {
-        //         // None
-        //         println!("post decode");
-        //         let sinkpools = sinkpools.clone();
-        //         let filenums = filenums.clone();
-        //         Some(
-        //             rt.spawn(async move {
-        //             // process_block(block, sinkpools, filenums).await
-        //         })
-        //     )
-        //     },
-        //     _ => {
-        //         // Ignore other blocks
-        //         None
-        //     }
-        // }
-        // Some(
-        //     rt.spawn(async move {
-        //                     // process_block(block, sinkpools, filenums).await
-        //                 })
-        // )
-    });
-    println!("{}", futures.count());
-    // rt.block_on(async {
-    //     tokio::join!(futures::future::join_all(futures))
-    // });
-    // tokio::join!(futures::future::join_all(futures));
-    // rt.block_on(future.await);
+    }
+
     Ok(())
 }
 
-// async fn local_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
-//     // let rt = tokio::runtime::Builder::new_multi_thread()
-//     // .enable_all()
-//     // .build()
-
-//     // .unwrap();
-//     // let blob_reader = BlobReader::from_path(ARGS.get().unwrap().input.clone()).unwrap();
-//     // let stream = stream::iter(blob_reader);
-// TODO - keep concurrency here
-//     // stream.for_each_concurrent(cpu_count() / 2, |blob| async {
-//     //     // TODO - fix unwrap
-//     //     process_block(blob.unwrap(), sinkpools.clone(), filenums.clone()).await
-//     // }).await;
-//     // rt.block_on(future.await);
-//     Ok(())
-// }
+fn local_read(sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>>, filenums: Arc<HashMap<OSMType, Arc<Mutex<u64>>>>) -> Result<(), osmpbf::Error> {
+    let blob_reader = BlobReader::from_path(ARGS.get().unwrap().input.clone()).unwrap();
+    blob_reader
+        .par_bridge()
+        .for_each(|blob| {
+            if let BlobDecode::OsmData(block) = blob.unwrap().decode().unwrap() {
+                process_block(block, sinkpools.clone(), filenums.clone());
+            }
+        });
+    Ok(())
+}
 
 pub fn driver(args: Args) -> Result<(), io::Error> {
     // TODO - validation of args
     // Store value for reading across threads (write-once)
     let _ = ARGS.set(args.clone());
-
-    // if args.input.starts_with("s3://") {
-    // } else {
-    //     let reader = BlobReader::from_path(args.input).unwrap();
-    // }
-    // TODO - need async blob reader
 
     let sinkpools: Arc<HashMap<OSMType, Arc<Mutex<Vec<ElementSink>>>>> = Arc::new(HashMap::from([
         (OSMType::Node, Arc::new(Mutex::new(vec![]))),
@@ -287,44 +123,18 @@ pub fn driver(args: Args) -> Result<(), io::Error> {
         (OSMType::Relation, Arc::new(Mutex::new(0))),
     ]));
 
-    // TODO - re-implement for local
-    // if args.input.starts_with("s3://") {
-    s3_read(sinkpools.clone(), filenums.clone());
-    // } else {
-    //     local_read(sinkpools.clone(), filenums.clone());
-    // }
-
-    // let get_sink_from_pool = |osm_type: OSMType| -> Result<ElementSink, std::io::Error> {
-
-    // };
-
-    // let add_sink_to_pool = 
-
-    // let stream = stream::iter(reader);
-
-
-
-    // reader
-    //     .par_bridge()
-    //     .try_for_each(|blob| -> Result<(), io::Error> {
-
-    // stream::StreamExt::try_for_each(stream, |blob| -> Result<(), io::Error> {
-    //     StreamExt::chunks_timeout(self, max_size, duration);
-        // rt.enter();
-        // TODO - async move?
-    // stream.try_for_each_concurrent(cpu_count() / 2, |blob| -> Result<(), io::Error> {
-    //     if let BlobDecode::OsmData(block) = blob?.decode()? {
-    //         process_block(block, sinkpools, filenums)?;
-    //     }
-    //     Ok(())
-    // })?;
+    if args.input.starts_with("s3://") {
+        s3_read(sinkpools.clone(), filenums.clone());
+    } else {
+        local_read(sinkpools.clone(), filenums.clone());
+    }
 
     {
         let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
         for sinkpool in sinkpools.values() {
             let mut pool = sinkpool.lock().unwrap();
             for mut sink in pool.drain(..) {
-                rt.block_on(sink.finish());
+                sink.finish();
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
 use std::io;
+use tokio;
 
 use clap::Parser;
 
 use osm_pbf_parquet::driver;
 use osm_pbf_parquet::util::Args;
 
-fn main() -> Result<(), io::Error> {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
     println!("{:?}", args);
-    let _ = driver(args);
-    Ok(())
+    driver(args).await.unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,12 @@
 use std::io;
-use tokio;
 
 use clap::Parser;
 
 use osm_pbf_parquet::driver;
 use osm_pbf_parquet::util::Args;
 
-// #[tokio::main]
 fn main() {
     let args = Args::parse();
     println!("{:?}", args);
-    // rt.block_on(
     let _ = driver(args);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use clap::Parser;
 
 use osm_pbf_parquet::driver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,10 @@ use clap::Parser;
 use osm_pbf_parquet::driver;
 use osm_pbf_parquet::util::Args;
 
-#[tokio::main]
-async fn main() {
+// #[tokio::main]
+fn main() {
     let args = Args::parse();
     println!("{:?}", args);
-    driver(args).await.unwrap();
+    // rt.block_on(
+    let _ = driver(args);
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -116,7 +116,7 @@ impl ElementSink {
         self.estimated_record_batch_bytes = 0;
     }
 
-    async fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
+    pub async fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
         if self.estimated_record_batch_bytes >= self.target_record_batch_bytes {
             self.finish_batch().await;
         }
@@ -189,7 +189,7 @@ impl ElementSink {
         path
     }
 
-    pub async fn add_node(&mut self, node: &Node<'_>) -> Result<(), std::io::Error> {
+    pub fn add_node(&mut self, node: &Node) { //-> Result<(), std::io::Error> {
         let info = node.info();
         let user = info
             .user()
@@ -215,10 +215,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle().await
+        // self.increment_and_cycle().await
     }
 
-    pub async fn add_dense_node(&mut self, node: &DenseNode<'_>) -> Result<(), std::io::Error> {
+    pub fn add_dense_node(&mut self, node: &DenseNode) { //-> Result<(), std::io::Error> {
         let info = node.info();
         let mut user: Option<String> = None;
         if let Some(info) = info {
@@ -243,10 +243,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle().await
+        // self.increment_and_cycle().await
     }
 
-    pub async fn add_way(&mut self, way: &Way<'_>) -> Result<(), std::io::Error> {
+    pub fn add_way(&mut self, way: &Way) { // -> Result<(), std::io::Error> {
         let info = way.info();
         let user = info
             .user()
@@ -272,10 +272,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle().await
+        // self.increment_and_cycle().await
     }
 
-    pub async fn add_relation(&mut self, relation: &Relation<'_>) -> Result<(), std::io::Error> {
+    pub fn add_relation(&mut self, relation: &Relation) { // -> Result<(), std::io::Error> {
         let info = relation.info();
         let user = info
             .user()
@@ -316,6 +316,6 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle().await
+        // self.increment_and_cycle().await
     }
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -31,7 +31,7 @@ pub struct ElementSink {
     estimated_file_bytes: usize,
     target_record_batch_bytes: usize,
     target_file_bytes: usize,
-    tokio_runtime: Arc<Runtime>,
+    // tokio_runtime: Arc<Runtime>,
 }
 
 impl ElementSink {
@@ -60,38 +60,41 @@ impl ElementSink {
             target_file_bytes: args.file_target_mb * 1_000_000usize,
 
             // Underlying object store writer (cloud/s3) needs to run in a tokio runtime context
-            tokio_runtime: Arc::new(
-                tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap(),
-            ),
+            // tokio_runtime: Arc::new(
+            //     tokio::runtime::Builder::new_multi_thread()
+            //         .enable_all()
+            //         .build()
+            //         .unwrap(),
+            // ),
         })
     }
 
-    pub fn finish(&mut self) {
-        self.finish_batch();
-        let _ = self
-            .tokio_runtime
-            .block_on(self.writer.take().unwrap().close());
+    pub async fn finish(&mut self) {
+        self.finish_batch().await;
+        // let _ = self
+        //     .tokio_runtime
+        //     .block_on(self.writer.take().unwrap().close());
+        self.writer.take().unwrap().close().await;
     }
 
-    fn finish_batch(&mut self) {
+    async fn finish_batch(&mut self) {
         if self.estimated_record_batch_bytes == 0 {
             // Nothing to write
             return;
         }
         let batch = self.osm_builder.finish().unwrap();
-        let _ = self
-            .tokio_runtime
-            .block_on(self.writer.as_mut().unwrap().write(&batch));
+        // let _ = self
+        //     .tokio_runtime
+        //     .block_on(self.writer.as_mut().unwrap().write(&batch));
+        self.writer.as_mut().unwrap().write(&batch).await;
 
         // Reset writer to new path if needed
         self.estimated_file_bytes += self.estimated_record_batch_bytes;
         if self.estimated_file_bytes >= self.target_file_bytes {
-            let _ = self
-                .tokio_runtime
-                .block_on(self.writer.take().unwrap().close());
+            // let _ = self
+            //     .tokio_runtime
+            //     .block_on(self.writer.take().unwrap().close());
+            self.writer.take().unwrap().close().await;
 
             // Create new writer and output
             let args = ARGS.get().unwrap();
@@ -113,9 +116,9 @@ impl ElementSink {
         self.estimated_record_batch_bytes = 0;
     }
 
-    fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
+    async fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
         if self.estimated_record_batch_bytes >= self.target_record_batch_bytes {
-            self.finish_batch();
+            self.finish_batch().await;
         }
         Ok(())
     }
@@ -186,7 +189,7 @@ impl ElementSink {
         path
     }
 
-    pub fn add_node(&mut self, node: &Node) -> Result<(), std::io::Error> {
+    pub async fn add_node(&mut self, node: &Node<'_>) -> Result<(), std::io::Error> {
         let info = node.info();
         let user = info
             .user()
@@ -212,10 +215,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle()
+        self.increment_and_cycle().await
     }
 
-    pub fn add_dense_node(&mut self, node: &DenseNode) -> Result<(), std::io::Error> {
+    pub async fn add_dense_node(&mut self, node: &DenseNode<'_>) -> Result<(), std::io::Error> {
         let info = node.info();
         let mut user: Option<String> = None;
         if let Some(info) = info {
@@ -240,10 +243,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle()
+        self.increment_and_cycle().await
     }
 
-    pub fn add_way(&mut self, way: &Way) -> Result<(), std::io::Error> {
+    pub async fn add_way(&mut self, way: &Way<'_>) -> Result<(), std::io::Error> {
         let info = way.info();
         let user = info
             .user()
@@ -269,10 +272,10 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle()
+        self.increment_and_cycle().await
     }
 
-    pub fn add_relation(&mut self, relation: &Relation) -> Result<(), std::io::Error> {
+    pub async fn add_relation(&mut self, relation: &Relation<'_>) -> Result<(), std::io::Error> {
         let info = relation.info();
         let user = info
             .user()
@@ -313,6 +316,6 @@ impl ElementSink {
         );
         self.estimated_record_batch_bytes += est_size_bytes;
 
-        self.increment_and_cycle()
+        self.increment_and_cycle().await
     }
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -113,7 +113,7 @@ impl ElementSink {
         self.estimated_record_batch_bytes = 0;
     }
 
-    pub fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
+    fn increment_and_cycle(&mut self) -> Result<(), std::io::Error> {
         if self.estimated_record_batch_bytes >= self.target_record_batch_bytes {
             self.finish_batch();
         }
@@ -186,7 +186,7 @@ impl ElementSink {
         path
     }
 
-    pub fn add_node(&mut self, node: &Node<'_>) -> Result<(), std::io::Error> {
+    pub fn add_node(&mut self, node: &Node) -> Result<(), std::io::Error> {
         let info = node.info();
         let user = info
             .user()
@@ -215,7 +215,7 @@ impl ElementSink {
         self.increment_and_cycle()
     }
 
-    pub fn add_dense_node(&mut self, node: &DenseNode<'_>) -> Result<(), std::io::Error> {
+    pub fn add_dense_node(&mut self, node: &DenseNode) -> Result<(), std::io::Error> {
         let info = node.info();
         let mut user: Option<String> = None;
         if let Some(info) = info {
@@ -243,7 +243,7 @@ impl ElementSink {
         self.increment_and_cycle()
     }
 
-    pub fn add_way(&mut self, way: &Way<'_>) -> Result<(), std::io::Error> {
+    pub fn add_way(&mut self, way: &Way) -> Result<(), std::io::Error> {
         let info = way.info();
         let user = info
             .user()
@@ -272,7 +272,7 @@ impl ElementSink {
         self.increment_and_cycle()
     }
 
-    pub fn add_relation(&mut self, relation: &Relation<'_>) -> Result<(), std::io::Error> {
+    pub fn add_relation(&mut self, relation: &Relation) -> Result<(), std::io::Error> {
         let info = relation.info();
         let user = info
             .user()

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,9 @@ use clap::Parser;
 // Write once, safe read across threads
 pub static ARGS: OnceLock<Args> = OnceLock::new();
 
+// Max recommended size of a single blob within a PBF (16MB)
+pub const DEFAULT_BUF_READER_SIZE: usize = 1024 * 1024 * 16;
+
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
-use sysinfo::System;
 use sysinfo::CpuRefreshKind;
 use sysinfo::RefreshKind;
+use sysinfo::System;
 
 use clap::Parser;
 
@@ -58,8 +58,7 @@ pub fn default_record_batch_size_mb() -> usize {
 }
 
 pub fn cpu_count() -> usize {
-    let system = System::new_with_specifics(
-        RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
-    );
+    let system =
+        System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
     return system.cpus().len();
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 // Write once, safe read across threads
 pub static ARGS: OnceLock<Args> = OnceLock::new();
 
-// Max recommended size of a single blob within a PBF (16MB)
-pub const DEFAULT_BUF_READER_SIZE: usize = 1024 * 1024 * 16;
+// Max recommended size of an uncompressed single blob is 16MB, assumes compression ratio of 2:1 or better
+pub const DEFAULT_BUF_READER_SIZE: usize = 1024 * 1024 * 8;
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,4 @@
 use std::sync::OnceLock;
-use sysinfo::CpuRefreshKind;
-use sysinfo::RefreshKind;
 use sysinfo::System;
 
 use clap::Parser;
@@ -55,10 +53,4 @@ pub fn default_record_batch_size_mb() -> usize {
     let system = System::new_all();
     // Estimate per thread available memory, leaving overhead for copies and system processes
     return ((system.total_memory() as usize / 1_000_000usize) / system.cpus().len()) / 8usize;
-}
-
-pub fn cpu_count() -> usize {
-    let system =
-        System::new_with_specifics(RefreshKind::new().with_cpu(CpuRefreshKind::everything()));
-    return system.cpus().len();
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,7 @@
 use std::sync::OnceLock;
 use sysinfo::System;
+use sysinfo::CpuRefreshKind;
+use sysinfo::RefreshKind;
 
 use clap::Parser;
 
@@ -53,4 +55,11 @@ pub fn default_record_batch_size_mb() -> usize {
     let system = System::new_all();
     // Estimate per thread available memory, leaving overhead for copies and system processes
     return ((system.total_memory() as usize / 1_000_000usize) / system.cpus().len()) / 8usize;
+}
+
+pub fn cpu_count() -> usize {
+    let system = System::new_with_specifics(
+        RefreshKind::new().with_cpu(CpuRefreshKind::everything()),
+    );
+    return system.cpus().len();
 }


### PR DESCRIPTION
Allows for PBFs to be read from local file or S3 stores, which assumes credentials are passed through environment variables as we do for writes.

This also switches to use zlib-ng and a much larger buffer size of 8MB (default is 8KB for `std::io::BufReader`, 1MB for `object_store::buffer::BufReader`)